### PR TITLE
feat(auth): implement sign-up functionality with form validation and …

### DIFF
--- a/apps/front/src/app/auth/auth.component.html
+++ b/apps/front/src/app/auth/auth.component.html
@@ -12,7 +12,7 @@
     <app-login [state]="state()" (userLoggedIn)="login($event)" />
   }
   @case (AuthState.SignUp) {
-    sign up
+    <app-sign-up [state]="state()" (userSignedUp)="signUp($event)" />
   }
   @default {
     <p>Please select a form to continue.</p>

--- a/apps/front/src/app/auth/auth.component.ts
+++ b/apps/front/src/app/auth/auth.component.ts
@@ -9,6 +9,7 @@ import { TuiTabs } from '@taiga-ui/kit';
 import { LoginComponent } from './login/login.component';
 import { AuthService } from './auth.service';
 import { AuthDto } from './auth.dto';
+import { SignUpComponent } from './sign-up/sign-up.component';
 
 enum AuthState {
   Login = 'login',
@@ -21,7 +22,7 @@ enum AuthState {
   styleUrls: ['./auth.component.less'],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, TuiTabs, LoginComponent],
+  imports: [ReactiveFormsModule, TuiTabs, LoginComponent, SignUpComponent],
   providers: [AuthService],
 })
 export class AuthComponent {
@@ -43,4 +44,9 @@ export class AuthComponent {
   protected login(dto: AuthDto) {
     this.authService.login(dto);
   }
+
+  protected signUp(dto: AuthDto) {
+    this.authService.signUp(dto);
+}
+
 }

--- a/apps/front/src/app/auth/sign-up/sign-up.component.html
+++ b/apps/front/src/app/auth/sign-up/sign-up.component.html
@@ -1,0 +1,58 @@
+<form [formGroup]="signUpForm" class="form">
+  <p>
+    <tui-input
+      [formControlName]="SignUpField.Email"
+      tuiTextfieldSize="l"
+      [tuiTextfieldCleaner]="true"
+    >
+      Type an email
+      <input autocomplete="email" tuiTextfieldLegacy type="email" />
+    </tui-input>
+    <tui-error
+      [formControlName]="SignUpField.Email"
+      [error]="[] | tuiFieldError | async"
+    />
+  </p>
+
+  <p>
+    <tui-input
+      [formControlName]="SignUpField.Password"
+      tuiTextfieldSize="l"
+      [tuiTextfieldCleaner]="true"
+    >
+      Type a password
+      <input autocomplete="new-password" tuiTextfieldLegacy type="password" />
+    </tui-input>
+    <tui-error
+      [formControlName]="SignUpField.Password"
+      [error]="[] | tuiFieldError | async"
+    />
+  </p>
+
+  <p>
+    <tui-input
+      [formControlName]="SignUpField.RepeatPassword"
+      tuiTextfieldSize="l"
+      [tuiTextfieldCleaner]="true"
+    >
+      Repeat password
+      <input autocomplete="new-password" tuiTextfieldLegacy type="password" />
+    </tui-input>
+    <tui-error
+      [formControlName]="SignUpField.RepeatPassword"
+      [error]="[] | tuiFieldError | async"
+    />
+  </p>
+
+  <button
+    class="button"
+    size="l"
+    tuiButton
+    type="button"
+    [disabled]="signUpForm.invalid || shouldShowLoading()"
+    [loading]="shouldShowLoading()"
+    (click)="signUp()"
+  >
+    Sign up
+  </button>
+</form>

--- a/apps/front/src/app/auth/sign-up/sign-up.component.ts
+++ b/apps/front/src/app/auth/sign-up/sign-up.component.ts
@@ -1,0 +1,102 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { State } from '../state';
+import { AuthDto } from '../auth.dto';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidationErrors,
+} from '@angular/forms';
+import {
+  emailValidator,
+  passwordLengthValidator,
+  requiredValidator,
+} from '../login/login.component';
+import { tuiMarkControlAsTouchedAndValidate } from '@taiga-ui/cdk';
+import { AsyncPipe } from '@angular/common';
+import { TuiButton, TuiError, TuiHint, TuiTextfield } from '@taiga-ui/core';
+import { TuiInputModule, TuiTextfieldControllerModule } from '@taiga-ui/legacy';
+import { TuiButtonLoading, TuiFieldErrorPipe } from '@taiga-ui/kit';
+
+function passwordMatchValidator(
+  group: AbstractControl,
+): ValidationErrors | null {
+  const password = group.get(SignUpField.Password)?.value;
+  const repeat = group.get(SignUpField.RepeatPassword)?.value;
+
+  return password === repeat ? null : { passwordMismatch: true };
+}
+
+enum SignUpField {
+  Email = 'email',
+  Password = 'password',
+  RepeatPassword = 'repeatPassword',
+}
+
+@Component({
+  selector: 'app-sign-up',
+  templateUrl: './sign-up.component.html',
+  styleUrls: ['./sign-up.component.less'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    AsyncPipe,
+    ReactiveFormsModule,
+    TuiHint,
+    TuiInputModule,
+    TuiTextfield,
+    TuiTextfieldControllerModule,
+    TuiFieldErrorPipe,
+    TuiError,
+    TuiButton,
+    TuiButtonLoading,
+  ],
+})
+export class SignUpComponent {
+  public readonly state = input.required<State | null>();
+
+  public readonly userSignedUp = output<AuthDto>();
+
+  protected readonly shouldShowLoading = computed(
+    () => this.state() === State.Loading,
+  );
+
+  protected readonly SignUpField = SignUpField;
+
+  protected readonly signUpForm = new FormGroup(
+    {
+      [SignUpField.Email]: new FormControl('', {
+        nonNullable: true,
+        validators: [requiredValidator, emailValidator],
+      }),
+      [SignUpField.Password]: new FormControl('', {
+        nonNullable: true,
+        validators: [requiredValidator, passwordLengthValidator],
+      }),
+      [SignUpField.RepeatPassword]: new FormControl('', {
+        nonNullable: true,
+        validators: [requiredValidator],
+      }),
+    },
+    { validators: [passwordMatchValidator] },
+  );
+
+  public signUp(): void {
+    tuiMarkControlAsTouchedAndValidate(this.signUpForm);
+
+    const { email, password } = this.signUpForm.value;
+
+    if (!this.signUpForm.valid || !email || !password) {
+      return;
+    }
+
+    this.userSignedUp.emit({ email, password });
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `SignUpComponent` to the authentication flow, enabling users to sign up with validation and error handling. It also updates the `AuthComponent` and `AuthService` to integrate the new sign-up functionality. Below is a summary of the most important changes:

### Addition of `SignUpComponent`:

* Created a new `SignUpComponent` with a form for user sign-up, including fields for email, password, and password confirmation. Added validation for required fields, email format, password length, and password match. [[1]](diffhunk://#diff-5d8b2ea484b1636e74fe489a1e67a4d0e48de53228e67d7be28acfeeaff9154eR1-R58) [[2]](diffhunk://#diff-30c65baa9f171e0fd1388dbda37de2342a2f9d4cc893444a780448715cccc624R1-R102)

### Updates to `AuthComponent`:

* Modified `auth.component.html` to include the `SignUpComponent` in the `AuthState.SignUp` case.
* Updated `auth.component.ts` to import `SignUpComponent` and add it to the `imports` array. Also added a `signUp` method to handle user sign-up events. [[1]](diffhunk://#diff-758cd9e20a13cb35a9416e2e2e2c14b4fe4246421643c393e6aebab80e23ef1dR12) [[2]](diffhunk://#diff-758cd9e20a13cb35a9416e2e2e2c14b4fe4246421643c393e6aebab80e23ef1dL24-R25) [[3]](diffhunk://#diff-758cd9e20a13cb35a9416e2e2e2c14b4fe4246421643c393e6aebab80e23ef1dR47-R51)

### Updates to `AuthService`:

* Added a `signUp` method in `AuthService` to handle API calls for user registration, manage state transitions, and navigate to the dashboard upon success.
* Injected the Angular `Router` service into `AuthService` for navigation purposes.…routing