### PR TITLE
 [P0.2] Configure Less stylePreprocessorOptions for short imports #83

### DIFF
--- a/apps/front/project.json
+++ b/apps/front/project.json
@@ -31,6 +31,9 @@
           "node_modules/@taiga-ui/core/styles/taiga-ui-fonts.less",
           "apps/front/src/styles.less"
         ],
+        "stylePreprocessorOptions": {
+          "includePaths": ["libs/front/ui-kit/src/lib/styles"]
+        },
         "scripts": []
       },
       "configurations": {


### PR DESCRIPTION
This pull request introduces a configuration improvement to the front-end application's build process by specifying additional include paths for style preprocessing. This change helps streamline the use of shared styles across the project.

Build configuration update:

* Updated the `stylePreprocessorOptions` in `apps/front/project.json` to include `libs/front/ui-kit/src/lib/styles` in the `includePaths`, making shared styles more accessible throughout the application.