### PR TITLE
[P1.1] Build Taiga compat-shim inside ui-kit #86

### DIFF
--- a/libs/front/ui-kit/src/lib/styles/taiga-compat.less
+++ b/libs/front/ui-kit/src/lib/styles/taiga-compat.less
@@ -1,0 +1,27 @@
+/*
+ * Taiga compat shim — temporary bridge.
+ * Delete in Phase 9 (after full Taiga removal).
+ */
+:root {
+  --tui-background-base: var(--color-surface-base);
+  --tui-background-elevation-1: var(--color-surface-raised);
+  --tui-background-elevation-2: var(--color-surface-sunken);
+
+  --tui-text-primary: var(--color-text-primary);
+  --tui-text-secondary: var(--color-text-secondary);
+  --tui-text-tertiary: var(--color-text-tertiary);
+
+  --tui-background-accent-1: var(--color-accent-primary);
+  --tui-background-accent-1-hover: var(--color-accent-primary-hover);
+  --tui-background-accent-1-pressed: var(--color-accent-primary-active);
+  --tui-text-action: var(--color-accent-primary);
+
+  --tui-border-normal: var(--color-border-default);
+  --tui-border-hover: var(--color-border-strong);
+  --tui-border-focus: var(--color-border-accent);
+
+  --tui-status-positive: var(--color-feedback-success);
+  --tui-status-warning: var(--color-feedback-warning);
+  --tui-status-negative: var(--color-feedback-danger);
+  --tui-status-info: var(--color-feedback-info);
+}


### PR DESCRIPTION
This pull request introduces a temporary compatibility shim to help bridge styles between the current system and the legacy Taiga UI library. This shim maps existing Taiga CSS custom properties to the new design system variables, easing the transition until Taiga is fully removed.

**Taiga compatibility shim:**

* Added a new stylesheet (`taiga-compat.less`) that defines CSS custom properties mapping Taiga UI variables (e.g., `--tui-background-base`, `--tui-text-primary`, etc.) to the new design system equivalents. This is intended as a temporary solution and will be removed after the full Taiga deprecation.