### PR TITLE
[P1.2] Wire tokens + compat-shim into apps/front/styles.less #87

### DIFF
--- a/apps/front/src/styles.less
+++ b/apps/front/src/styles.less
@@ -1,9 +1,14 @@
+// 1. Our tokens declare CSS variables on :root
+@import 'tokens';
+
+// 2. Taiga's own styles (will be overridden by the shim below)
 @import '@taiga-ui/core/styles/taiga-ui-local.less';
 
+// 3. The compat-shim from ui-kit (deleted in Phase 9)
+@import 'taiga-compat';
+
+// 4. App-specific custom variables remain
 :root {
-  --lifestyle-color: var(--tui-chart-categorical-15);
-  --lifestyle-color-hover: var(--tui-chart-categorical-16);
-  --tui-background-accent-1: var(--lifestyle-color);
-  --tui-background-accent-1-hover: var(--lifestyle-color-hover);
-  --tui-text-action: var(--lifestyle-color-hover);
+  --lifestyle-color: var(--color-accent-primary);
+  --lifestyle-color-hover: var(--color-accent-primary-hover);
 }

--- a/libs/front/ui-kit/src/lib/styles/tokens.less
+++ b/libs/front/ui-kit/src/lib/styles/tokens.less
@@ -89,9 +89,9 @@
   --color-accent-secondary:      var(--_color-mint-500);
 
   /* Category (stable semantic mapping, independent of mode) */
-  --color-category-health:  var(--_color-coral-500);
-  --color-category-leisure: var(--_color-violet-500);
-  --color-category-routine: var(--_color-emerald-500);
+  --color-category-health:  var(--_color-emerald-500);
+  --color-category-leisure: var(--_color-coral-500);
+  --color-category-routine: var(--_color-violet-500);
   --color-category-selfdev: var(--_color-amber-500);
 
   /* Feedback */


### PR DESCRIPTION
This pull request updates the application's color theming by adjusting CSS variable assignments and reorganizing imports in the main stylesheet. The most significant changes involve updating the mapping of category colors and ensuring the correct order of style imports for maintainability and future compatibility.

**Theme variable updates:**

* Swapped the color assignments for `--color-category-health`, `--color-category-leisure`, and `--color-category-routine` to better align with their intended semantic meanings in `tokens.less`. (`libs/front/ui-kit/src/lib/styles/tokens.less`)
* Updated `--lifestyle-color` and `--lifestyle-color-hover` to reference new accent color variables, improving consistency across the app. (`apps/front/src/styles.less`)

**Stylesheet organization:**

* Reordered imports in `styles.less` to first include token declarations, then Taiga UI styles, followed by a compatibility shim, and finally app-specific custom variables. This prepares for future removal of the compatibility shim and clarifies the styling cascade. (`apps/front/src/styles.less`)