### PR TITLE
[P2.1] Build lf-button + replace TuiButton in 6 files #89

### DIFF
--- a/apps/front/src/app/auth/login/login.component.html
+++ b/apps/front/src/app/auth/login/login.component.html
@@ -33,8 +33,8 @@
 
   <button
     class="button"
-    size="l"
-    tuiButton
+    size="lg"
+    lifeelbutton
     type="submit"
     [disabled]="loginForm.invalid || shouldShowLoading()"
     [loading]="shouldShowLoading()"

--- a/apps/front/src/app/auth/login/login.component.ts
+++ b/apps/front/src/app/auth/login/login.component.ts
@@ -10,9 +10,10 @@ import {
   Validators,
 } from '@angular/forms';
 import { tuiMarkControlAsTouchedAndValidate } from '@taiga-ui/cdk';
-import { TuiButton, TuiError, TuiHint, TuiLabel, TuiTextfield } from '@taiga-ui/core';
-import { TuiButtonLoading, TuiFieldErrorPipe } from '@taiga-ui/kit';
+import { TuiError, TuiHint, TuiLabel, TuiTextfield } from '@taiga-ui/core';
+import { TuiFieldErrorPipe } from '@taiga-ui/kit';
 import { State } from '@lifestyle-dashboard/state';
+import { LifeelButton } from '@lifestyle-dashboard/ui-kit';
 import { AuthDto } from '../auth.dto';
 
 export const PASSWORD_MIN_LENGTH = 7;
@@ -34,9 +35,8 @@ enum LoginField {
     TuiTextfield,
     TuiFieldErrorPipe,
     TuiError,
-    TuiButton,
-    TuiButtonLoading,
     TuiLabel,
+    LifeelButton,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/front/src/app/auth/sign-up/sign-up.component.html
+++ b/apps/front/src/app/auth/sign-up/sign-up.component.html
@@ -62,8 +62,8 @@
 
   <button
     class="button"
-    size="l"
-    tuiButton
+    size="lg"
+    lifeelbutton
     type="submit"
     [disabled]="signUpForm.invalid || shouldShowLoading"
     [loading]="shouldShowLoading"

--- a/apps/front/src/app/auth/sign-up/sign-up.component.ts
+++ b/apps/front/src/app/auth/sign-up/sign-up.component.ts
@@ -10,16 +10,10 @@ import {
   Validators,
 } from '@angular/forms';
 import { tuiMarkControlAsTouchedAndValidate } from '@taiga-ui/cdk';
-import {
-  TuiButton,
-  TuiError,
-  TuiHint,
-  TuiLabel,
-  TuiNotification,
-  TuiTextfield,
-} from '@taiga-ui/core';
-import { TuiButtonLoading, TuiFieldErrorPipe } from '@taiga-ui/kit';
+import { TuiError, TuiHint, TuiLabel, TuiNotification, TuiTextfield } from '@taiga-ui/core';
+import { TuiFieldErrorPipe } from '@taiga-ui/kit';
 import { State } from '@lifestyle-dashboard/state';
+import { LifeelButton } from '@lifestyle-dashboard/ui-kit';
 import { AuthDto } from '../auth.dto';
 import { PASSWORD_MIN_LENGTH } from '../login/login.component';
 
@@ -51,10 +45,9 @@ enum SignUpField {
     TuiTextfield,
     TuiFieldErrorPipe,
     TuiError,
-    TuiButton,
-    TuiButtonLoading,
     TuiLabel,
     TuiNotification,
+    LifeelButton,
   ],
 })
 export class SignUpComponent implements OnInit {

--- a/apps/front/src/app/settings/widget-layout-settings/widget-layout-settings.component.html
+++ b/apps/front/src/app/settings/widget-layout-settings/widget-layout-settings.component.html
@@ -35,7 +35,7 @@
   }
 </div>
 
-<button size="l" tuiButton type="button" (click)="save()" [loading]="$shouldShowLoading()">
+<button size="lg" lifeelbutton type="button" (click)="save()" [loading]="$shouldShowLoading()">
   Save settings
 </button>
 

--- a/apps/front/src/app/settings/widget-layout-settings/widget-layout-settings.component.ts
+++ b/apps/front/src/app/settings/widget-layout-settings/widget-layout-settings.component.ts
@@ -2,17 +2,17 @@ import { KeyValue, KeyValuePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
-  TuiButton,
   TuiLabel,
   TuiTextfield,
   TuiTextfieldDirective,
   TuiTextfieldDropdownDirective,
   TuiTitle,
 } from '@taiga-ui/core';
-import { TuiButtonLoading, TuiChevron, TuiDataListWrapper, TuiSelect } from '@taiga-ui/kit';
+import { TuiChevron, TuiDataListWrapper, TuiSelect } from '@taiga-ui/kit';
 import { TuiHeader } from '@taiga-ui/layout';
 import { Layout } from '@lifestyle-dashboard/config';
 import { State } from '@lifestyle-dashboard/state';
+import { LifeelButton } from '@lifestyle-dashboard/ui-kit';
 import { Slot, WidgetOptions, WidgetType } from '@lifestyle-dashboard/widget-contracts';
 import { WidgetRegistry } from '@lifestyle-dashboard/widget-registry';
 import { WidgetLayoutSettingsService } from './widget-layout-settings.service';
@@ -34,10 +34,9 @@ import { WIDGET_LAYOUT_SLOT_MAP } from './widget-layout-slots';
     TuiSelect,
     TuiTextfieldDirective,
     TuiTextfieldDropdownDirective,
-    TuiButton,
     TuiHeader,
     TuiTitle,
-    TuiButtonLoading,
+    LifeelButton,
   ],
 })
 export class WidgetLayoutSettingsComponent {

--- a/apps/front/src/styles.less
+++ b/apps/front/src/styles.less
@@ -7,6 +7,14 @@
 // 3. The compat-shim from ui-kit (deleted in Phase 9)
 @import 'taiga-compat';
 
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
 // 4. App-specific custom variables remain
 :root {
   --lifestyle-color: var(--color-accent-primary);

--- a/libs/front/ui-kit/README.md
+++ b/libs/front/ui-kit/README.md
@@ -61,7 +61,7 @@ No deep imports — only the public API at `src/index.ts`.
 ### Using a component
 
 ```html
-<button lfButton variant="primary" size="md" (click)="save()">Save</button>
+<button lifeelButton variant="primary" size="md" (click)="save()">Save</button>
 
 <lf-icon name="settings" />
 
@@ -123,7 +123,7 @@ Contract for any new primitive:
 1. **Standalone** — `standalone: true`. No `NgModule`.
 2. **OnPush** — `changeDetection: ChangeDetectionStrategy.OnPush`.
 3. **Signal-based API** — `input()`, `model()`, `output()` over `@Input()`/`@Output()`.
-4. **Selector convention** — element + attribute: `lf-button, button[lfButton], a[lfButton]`.
+4. **Selector convention** — element + attribute: `lf-button, button[lifeelButton], a[lifeelButton]`.
 5. **Token-only styles** — no hex colors, no rgb literals; sizes via `var(--space-*)`, radii via `var(--radius-*)`.
 6. **Public API only** — export from `src/index.ts`. No deep imports for consumers.
 7. **Story file required** — `<name>.component.stories.ts` next to the component. At minimum: one story per `variant`, plus an `AllStates` overview.
@@ -159,7 +159,7 @@ const meta: Meta<ButtonComponent> = {
   render: (args) => ({
     props: args,
     template: `
-      <button lfButton [variant]="variant" [size]="size" [loading]="loading">
+      <button lifeelButton [variant]="variant" [size]="size" [loading]="loading">
         Save
       </button>
     `,
@@ -177,9 +177,9 @@ export const AllSizes: Story = {
   render: () => ({
     template: `
       <div style="display:flex; gap:12px; align-items:center;">
-        <button lfButton size="sm">Small</button>
-        <button lfButton size="md">Medium</button>
-        <button lfButton size="lg">Large</button>
+        <button lifeelButton size="sm">Small</button>
+        <button lifeelButton size="md">Medium</button>
+        <button lifeelButton size="lg">Large</button>
       </div>
     `,
   }),
@@ -190,7 +190,7 @@ export const AllSizes: Story = {
 
 | Topic | Rule |
 |---|---|
-| Selectors | `lf-` prefix on elements (`lf-button`), `lfX` on attribute directives (`lfButton`, `lfTooltip`) |
+| Selectors | `lf-` prefix on elements (`lf-button`), `lfX` on attribute directives (`lifeelButton`, `lfTooltip`) |
 | Style language | Less, not SCSS — matches the rest of the app |
 | Colors in styles | Only `var(--color-*)`. No hex, no rgb literals. |
 | Spacing | `var(--space-1)` … `var(--space-20)`. No raw px outside tokens. |

--- a/libs/front/ui-kit/README.md
+++ b/libs/front/ui-kit/README.md
@@ -18,7 +18,7 @@ libs/front/ui-kit/src/lib/
 │   └── theme.service.ts     # light / dark switcher
 ├── components/              # atoms + molecules + dialog + tooltip
 ├── forms/                   # form utils (markAllControlsTouchedAndValidate)
-└── icons/                   # lf-icon over lucide-angular
+└── icons/                   # lifeel-icon over lucide-angular
 ```
 
 ## Quick start
@@ -63,13 +63,13 @@ No deep imports — only the public API at `src/index.ts`.
 ```html
 <button lifeelButton variant="primary" size="md" (click)="save()">Save</button>
 
-<lf-icon name="settings" />
+<lifeel-icon name="settings" />
 
-<lf-form-field>
+<lifeel-form-field>
   <span slot="label">Email</span>
-  <lf-textfield type="email" formControlName="email" />
+  <lifeel-textfield type="email" formControlName="email" />
   <span slot="error">Invalid email</span>
-</lf-form-field>
+</lifeel-form-field>
 ```
 
 ### Switching theme
@@ -123,7 +123,7 @@ Contract for any new primitive:
 1. **Standalone** — `standalone: true`. No `NgModule`.
 2. **OnPush** — `changeDetection: ChangeDetectionStrategy.OnPush`.
 3. **Signal-based API** — `input()`, `model()`, `output()` over `@Input()`/`@Output()`.
-4. **Selector convention** — element + attribute: `lf-button, button[lifeelButton], a[lifeelButton]`.
+4. **Selector convention** — element + attribute: `lifeelButton-button, button[lifeelButton], a[lifeelButton]`.
 5. **Token-only styles** — no hex colors, no rgb literals; sizes via `var(--space-*)`, radii via `var(--radius-*)`.
 6. **Public API only** — export from `src/index.ts`. No deep imports for consumers.
 7. **Story file required** — `<name>.component.stories.ts` next to the component. At minimum: one story per `variant`, plus an `AllStates` overview.
@@ -190,7 +190,7 @@ export const AllSizes: Story = {
 
 | Topic | Rule |
 |---|---|
-| Selectors | `lf-` prefix on elements (`lf-button`), `lfX` on attribute directives (`lifeelButton`, `lfTooltip`) |
+| Selectors | `lifeel-` prefix on elements (`lifeel-button`), `lifeelX` on attribute directives (`lifeelButton`, `lifeelTooltip`) |
 | Style language | Less, not SCSS — matches the rest of the app |
 | Colors in styles | Only `var(--color-*)`. No hex, no rgb literals. |
 | Spacing | `var(--space-1)` … `var(--space-20)`. No raw px outside tokens. |

--- a/libs/front/ui-kit/src/index.ts
+++ b/libs/front/ui-kit/src/index.ts
@@ -1,2 +1,5 @@
 export * from './lib/tokens/tokens';
 export * from './lib/theme/theme.service';
+
+// Components
+export * from './lib/components/button/button.component';

--- a/libs/front/ui-kit/src/lib/components/button/button.component.html
+++ b/libs/front/ui-kit/src/lib/components/button/button.component.html
@@ -1,0 +1,7 @@
+@if (loading()) {
+  <span class="lifeel-button__loader" aria-hidden="true"></span>
+}
+
+<span class="lifeel-button__content">
+  <ng-content></ng-content>
+</span>

--- a/libs/front/ui-kit/src/lib/components/button/button.component.less
+++ b/libs/front/ui-kit/src/lib/components/button/button.component.less
@@ -1,0 +1,113 @@
+@import '../../styles/tokens.less';
+
+:host {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: 12px var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  transition: all var(--duration-fast) var(--ease-out);
+  white-space: nowrap;
+  border: 0;
+}
+
+:host(:focus-visible) {
+  outline: 0;
+  box-shadow: var(--shadow-focus-ring);
+}
+
+:host(.lifeel-button--primary) {
+  background: var(--color-accent-primary);
+  color: var(--color-text-on-accent);
+  box-shadow: var(--shadow-sm);
+}
+
+:host(.lifeel-button--primary:hover) {
+  background: var(--color-accent-primary-hover);
+  box-shadow: var(--shadow-md);
+}
+
+:host(.lifeel-button--primary:active) {
+  background: var(--color-accent-primary-active);
+}
+
+:host(.lifeel-button--secondary) {
+  background: var(--color-surface-accent-soft);
+  color: var(--color-text-accent);
+  border: 1px solid transparent;
+}
+
+:host(.lifeel-button--secondary:hover) {
+  background: var(--color-surface-accent-mid);
+}
+
+:host(.lifeel-button--ghost) {
+  color: var(--color-text-secondary);
+}
+
+:host(.lifeel-button--ghost:hover) {
+  background: var(--color-surface-sunken);
+  color: var(--color-text-primary);
+}
+
+:host(.lifeel-button--danger) {
+  background: var(--color-feedback-danger);
+  color: var(--color-text-on-accent);
+}
+
+:host(.lifeel-button--danger:hover) {
+  filter: brightness(0.95);
+}
+
+:host(.is-disabled),
+:host([disabled]) {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+:host(.lifeel-button--sm) {
+  padding: 8px var(--space-3);
+  font-size: var(--font-size-xs);
+  border-radius: var(--radius-sm);
+}
+
+:host(.lifeel-button--lg) {
+  padding: 16px var(--space-5);
+  font-size: var(--font-size-base);
+}
+
+:host(.is-loading) {
+  position: relative;
+  color: transparent;
+  pointer-events: none;
+}
+
+:host(.is-loading)::after {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-full);
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  color: var(--color-text-on-accent);
+  animation: spin 0.7s linear infinite;
+}
+
+:host(.lifeel-button--secondary.is-loading)::after {
+  color: var(--color-text-accent);
+}
+
+:host(.lifeel-button--ghost.is-loading)::after {
+  color: var(--color-text-primary);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/libs/front/ui-kit/src/lib/components/button/button.component.spec.ts
+++ b/libs/front/ui-kit/src/lib/components/button/button.component.spec.ts
@@ -1,0 +1,102 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { LifeelButton } from './button.component';
+
+@Component({
+  standalone: true,
+  imports: [LifeelButton],
+  template: `
+    <button
+      lifeelbutton
+      [variant]="variant"
+      [size]="size"
+      [loading]="loading"
+      [disabled]="disabled"
+    >
+      {{ label }}
+    </button>
+  `,
+})
+class HostComponent {
+  public variant: 'primary' | 'secondary' | 'ghost' | 'danger' = 'primary';
+  public size: 'sm' | 'md' | 'lg' = 'md';
+  public disabled = false;
+  public loading = false;
+  public label = 'Save';
+}
+
+describe('LifeelButton', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let hostComponent: HostComponent;
+
+  const getButton = (): HTMLButtonElement =>
+    fixture.debugElement.query(By.css('button[lifeelbutton]')).nativeElement as HTMLButtonElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    hostComponent = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('applies default host classes', () => {
+    const button = getButton();
+
+    expect(button.classList.contains('lifeel-button')).toBe(true);
+    expect(button.classList.contains('lifeel-button--primary')).toBe(true);
+    expect(button.classList.contains('lifeel-button--md')).toBe(true);
+  });
+
+  it('updates variant and size classes from inputs', () => {
+    hostComponent.variant = 'danger';
+    hostComponent.size = 'lg';
+    fixture.detectChanges();
+
+    const button = getButton();
+
+    expect(button.classList.contains('lifeel-button--danger')).toBe(true);
+    expect(button.classList.contains('lifeel-button--lg')).toBe(true);
+    expect(button.classList.contains('lifeel-button--primary')).toBe(false);
+    expect(button.classList.contains('lifeel-button--md')).toBe(false);
+  });
+
+  it('sets disabled state on host attributes and classes', () => {
+    hostComponent.disabled = true;
+    fixture.detectChanges();
+
+    const button = getButton();
+
+    expect(button.classList.contains('is-disabled')).toBe(true);
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+    expect(button.getAttribute('disabled')).toBe('');
+  });
+
+  it('sets loading state and renders loader', () => {
+    hostComponent.loading = true;
+    fixture.detectChanges();
+
+    const button = getButton();
+    const loader = fixture.debugElement.query(By.css('.lifeel-button__loader'));
+    const content = fixture.debugElement.query(By.css('.lifeel-button__content'));
+
+    expect(button.classList.contains('is-loading')).toBe(true);
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+    expect(button.getAttribute('disabled')).toBe('');
+    expect(loader).not.toBeNull();
+    expect(loader.nativeElement.getAttribute('aria-hidden')).toBe('true');
+    expect(content.nativeElement.textContent.trim()).toBe('Save');
+  });
+
+  it('projects button content into the content container', () => {
+    hostComponent.label = 'Delete';
+    fixture.detectChanges();
+
+    const content = fixture.debugElement.query(By.css('.lifeel-button__content'));
+
+    expect(content.nativeElement.textContent.trim()).toBe('Delete');
+  });
+});

--- a/libs/front/ui-kit/src/lib/components/button/button.component.stories.ts
+++ b/libs/front/ui-kit/src/lib/components/button/button.component.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta<LifeelButton> = {
     variant: {
       control: 'select',
 
-      options: ['primary', 'ghost', 'secondary', 'danger'],
+      options: ['primary', 'secondary', 'ghost', 'secondary', 'danger'],
     },
 
     size: {
@@ -67,6 +67,40 @@ export const Primary: Story = {
       >
 
         Primary button
+
+      </button>
+
+    `,
+  }),
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+
+    loading: true,
+  },
+
+  render: (args) => ({
+    props: args,
+
+    template: `
+
+      <button
+
+        lifeelbutton
+
+        [variant]="variant"
+
+        [size]="size"
+
+        [loading]="loading"
+
+        [disabled]="disabled"
+
+      >
+
+        Saving
 
       </button>
 

--- a/libs/front/ui-kit/src/lib/components/button/button.component.stories.ts
+++ b/libs/front/ui-kit/src/lib/components/button/button.component.stories.ts
@@ -1,0 +1,225 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { LifeelButton } from './button.component';
+
+const meta: Meta<LifeelButton> = {
+  title: 'UI Kit/Button',
+  component: LifeelButton,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+
+      options: ['primary', 'ghost', 'secondary', 'danger'],
+    },
+
+    size: {
+      control: 'select',
+
+      options: ['sm', 'md', 'lg'],
+    },
+
+    loading: {
+      control: 'boolean',
+    },
+
+    disabled: {
+      control: 'boolean',
+    },
+  },
+
+  args: {
+    variant: 'primary',
+
+    size: 'md',
+
+    loading: false,
+
+    disabled: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<LifeelButton>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+  },
+
+  render: (args) => ({
+    props: args,
+
+    template: `
+
+      <button
+
+        lifeelbutton
+
+        [variant]="variant"
+
+        [size]="size"
+
+        [loading]="loading"
+
+        [disabled]="disabled"
+
+      >
+
+        Primary button
+
+      </button>
+
+    `,
+  }),
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+  },
+
+  render: (args) => ({
+    props: args,
+
+    template: `
+
+      <button
+
+        lifeelbutton
+
+        [variant]="variant"
+
+        [size]="size"
+
+        [loading]="loading"
+
+        [disabled]="disabled"
+
+      >
+
+        Ghost button
+
+      </button>
+
+    `,
+  }),
+};
+
+export const Danger: Story = {
+  args: {
+    variant: 'danger',
+  },
+
+  render: (args) => ({
+    props: args,
+
+    template: `
+
+      <button
+
+        lifeelbutton
+
+        [variant]="variant"
+
+        [size]="size"
+
+        [loading]="loading"
+
+        [disabled]="disabled"
+
+      >
+
+        Delete
+
+      </button>
+
+    `,
+  }),
+};
+
+export const Loading: Story = {
+  args: {
+    variant: 'primary',
+
+    loading: true,
+  },
+
+  render: (args) => ({
+    props: args,
+
+    template: `
+
+      <button
+
+        lifeelbutton
+
+        [variant]="variant"
+
+        [size]="size"
+
+        [loading]="loading"
+
+        [disabled]="disabled"
+
+      >
+
+        Saving
+
+      </button>
+
+    `,
+  }),
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: 'primary',
+
+    disabled: true,
+  },
+
+  render: (args) => ({
+    props: args,
+
+    template: `
+
+      <button
+
+        lifeelbutton
+
+        [variant]="variant"
+
+        [size]="size"
+
+        [loading]="loading"
+
+        [disabled]="disabled"
+
+      >
+
+        Disabled button
+
+      </button>
+
+    `,
+  }),
+};
+
+export const AllSizes: Story = {
+  render: () => ({
+    template: `
+
+      <div style="display: flex; align-items: center; gap: 16px;">
+
+        <button lifeelbutton size="sm">Small</button>
+
+        <button lifeelbutton size="md">Medium</button>
+
+        <button lifeelbutton size="lg">Large</button>
+
+      </div>
+
+    `,
+  }),
+};

--- a/libs/front/ui-kit/src/lib/components/button/button.component.ts
+++ b/libs/front/ui-kit/src/lib/components/button/button.component.ts
@@ -1,0 +1,38 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Size, Variant } from '../../tokens/tokens';
+
+@Component({
+  selector: 'lifeel-button, button[lifeelbutton], a[lifeelbutton]',
+  standalone: true,
+  templateUrl: './button.component.html',
+  styleUrls: ['./button.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class]': 'hostClasses()',
+
+    '[attr.aria-disabled]': 'disabled() || loading() ? "true" : null',
+
+    '[attr.disabled]': 'isNativeButtonDisabled() ? "" : null',
+  },
+})
+export class LifeelButton {
+  public readonly variant = input<Variant>('primary');
+  public readonly size = input<Size>('md');
+
+  public readonly disabled = input<boolean>(false);
+  public readonly loading = input<boolean>(false);
+
+  protected readonly hostClasses = computed(() => {
+    return [
+      'lifeel-button',
+      `lifeel-button--${this.variant()}`,
+      `lifeel-button--${this.size()}`,
+      this.disabled() ? 'is-disabled' : '',
+      this.loading() ? 'is-loading' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  });
+
+  protected readonly isNativeButtonDisabled = computed(() => this.disabled() || this.loading());
+}

--- a/libs/front/ui-kit/src/lib/tokens/tokens.ts
+++ b/libs/front/ui-kit/src/lib/tokens/tokens.ts
@@ -239,6 +239,8 @@ export type CategoryKey = keyof typeof semanticTokens.color.category;
 export type SpaceKey = keyof typeof semanticTokens.space;
 export type RadiusKey = keyof typeof semanticTokens.radius;
 export type ShadowKey = keyof typeof semanticTokens.shadow;
+export type Variant = 'primary' | 'ghost' | 'secondary' | 'danger';
+export type Size = 'sm' | 'md' | 'lg';
 
 // ─── Convenience: the four Time Tracker categories in a stable order ─────────
 export const TIME_TRACKER_CATEGORIES: readonly {

--- a/libs/front/ui/day-card-dialog/src/lib/day-card-dialog/day-card-dialog.component.html
+++ b/libs/front/ui/day-card-dialog/src/lib/day-card-dialog/day-card-dialog.component.html
@@ -30,8 +30,8 @@
 
   <div class="button-container">
     <button
-      size="l"
-      tuiButton
+      size="lg"
+      lifeelbutton
       type="button"
       class="button"
       appearance="secondary"

--- a/libs/front/ui/day-card-dialog/src/lib/day-card-dialog/day-card-dialog.component.html
+++ b/libs/front/ui/day-card-dialog/src/lib/day-card-dialog/day-card-dialog.component.html
@@ -34,7 +34,7 @@
       lifeelbutton
       type="button"
       class="button"
-      appearance="secondary"
+      variant="secondary"
       (click)="save(shownWidget.key)"
     >
       Save

--- a/libs/front/ui/day-card-dialog/src/lib/day-card-dialog/day-card-dialog.component.ts
+++ b/libs/front/ui/day-card-dialog/src/lib/day-card-dialog/day-card-dialog.component.ts
@@ -8,11 +8,12 @@ import {
   Signal,
   signal,
 } from '@angular/core';
-import { TuiButton, TuiIconPipe, type TuiDialogContext } from '@taiga-ui/core';
+import { TuiIconPipe, type TuiDialogContext } from '@taiga-ui/core';
 import { TuiTabs } from '@taiga-ui/kit';
 import { injectContext } from '@taiga-ui/polymorpheus';
 import { DynamicHostComponent } from '@lifestyle-dashboard/dynamic-host';
 import { DayWidgetData } from '@lifestyle-dashboard/lifestyle-widget-data-service';
+import { LifeelButton } from '@lifestyle-dashboard/ui-kit';
 import { WidgetSettingsComponent, WidgetType } from '@lifestyle-dashboard/widget-contracts';
 import { WidgetIconPipe, WidgetNamePipe } from '@lifestyle-dashboard/widget-name-pipe';
 import { DayCardDialogService } from './day-card-dialog.service';
@@ -29,7 +30,14 @@ export interface DayCardDialogContext {
 @Component({
   selector: 'lifestyle-day-card-dialog',
   standalone: true,
-  imports: [TuiTabs, TuiIconPipe, TuiButton, WidgetNamePipe, WidgetIconPipe, DynamicHostComponent],
+  imports: [
+    TuiTabs,
+    TuiIconPipe,
+    LifeelButton,
+    WidgetNamePipe,
+    WidgetIconPipe,
+    DynamicHostComponent,
+  ],
   templateUrl: './day-card-dialog.component.html',
   styleUrl: './day-card-dialog.component.less',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/front/ui/header/src/lib/header/header.component.html
+++ b/libs/front/ui/header/src/lib/header/header.component.html
@@ -10,7 +10,6 @@
   class="profile"
   tuiIconButton
   size="s"
-  [tuiAppearanceState]="openedDropdown ? 'active' : null"
   [tuiDropdown]="dropdown"
   [(tuiDropdownOpen)]="openedDropdown"
   tuiDropdownDirection="bottom"
@@ -33,7 +32,7 @@
       }
     </tui-opt-group>
     <tui-opt-group>
-      <button tuiButton type="button" (click)="logout()">Log out</button>
+      <button lifeelButton type="button" (click)="logout()">Log out</button>
     </tui-opt-group>
   </tui-data-list>
 </ng-template>

--- a/libs/front/ui/header/src/lib/header/header.component.html
+++ b/libs/front/ui/header/src/lib/header/header.component.html
@@ -3,6 +3,7 @@
   Lifeel
 </div>
 
+<!-- to return: [tuiAppearanceState]="openedDropdown ? 'active' : null" -->
 <button
   appearance="outline"
   type="button"

--- a/libs/front/ui/header/src/lib/header/header.component.ts
+++ b/libs/front/ui/header/src/lib/header/header.component.ts
@@ -1,11 +1,12 @@
 import { ChangeDetectionStrategy, Component, output } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { TuiButton, TuiDataList, TuiDropdown, TuiIcon } from '@taiga-ui/core';
+import { TuiDataList, TuiDropdown, TuiIcon } from '@taiga-ui/core';
+import { LifeelButton } from '@lifestyle-dashboard/ui-kit';
 import { HEADER_LINKS } from './header-links';
 
 @Component({
   selector: 'lifestyle-dashboard-header',
-  imports: [RouterLink, RouterLinkActive, TuiIcon, TuiButton, TuiDataList, TuiDropdown],
+  imports: [RouterLink, RouterLinkActive, TuiIcon, LifeelButton, TuiDataList, TuiDropdown],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/front/ui/sport-activities-widget/src/lib/sport-activities-settings-widget/sport-activities-settings-widget.component.html
+++ b/libs/front/ui/sport-activities-widget/src/lib/sport-activities-settings-widget/sport-activities-settings-widget.component.html
@@ -1,4 +1,4 @@
-<button appearance="secondary" size="m" tuiButton type="button" (click)="addActivity()">
+<button appearance="secondary" size="md" lifeelButton type="button" (click)="addActivity()">
   <tui-icon icon="@tui.circle-plus" [style.height.rem]="1" />
   Add activity
 </button>

--- a/libs/front/ui/sport-activities-widget/src/lib/sport-activities-settings-widget/sport-activities-settings-widget.component.html
+++ b/libs/front/ui/sport-activities-widget/src/lib/sport-activities-settings-widget/sport-activities-settings-widget.component.html
@@ -1,4 +1,4 @@
-<button appearance="secondary" size="md" lifeelButton type="button" (click)="addActivity()">
+<button variant="secondary" size="md" lifeelButton type="button" (click)="addActivity()">
   <tui-icon icon="@tui.circle-plus" [style.height.rem]="1" />
   Add activity
 </button>

--- a/libs/front/ui/sport-activities-widget/src/lib/sport-activities-settings-widget/sport-activities-settings-widget.component.ts
+++ b/libs/front/ui/sport-activities-widget/src/lib/sport-activities-settings-widget/sport-activities-settings-widget.component.ts
@@ -2,8 +2,9 @@ import { type MaskitoTimeMode } from '@maskito/kit';
 import { Component, computed, inject, OnInit, Signal } from '@angular/core';
 import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TuiTime } from '@taiga-ui/cdk';
-import { TuiButton, TuiIcon, TuiTextfield } from '@taiga-ui/core';
+import { TuiIcon, TuiTextfield } from '@taiga-ui/core';
 import { TuiInputTime } from '@taiga-ui/kit';
+import { LifeelButton } from '@lifestyle-dashboard/ui-kit';
 import { WidgetSettingsComponent } from '@lifestyle-dashboard/widget-contracts';
 import { SportActivitiesWidgetInput } from '../sport-activities-widget-input';
 import { SPORT_ACTIVITIES_WIDGET_TOKEN } from '../sport-activities-widget.token';
@@ -28,7 +29,7 @@ type ActivityGroup = FormGroup<{
 
 @Component({
   selector: 'lifestyle-dashboard-sport-activities-settings-widget',
-  imports: [ReactiveFormsModule, TuiButton, TuiIcon, TuiTextfield, TuiInputTime],
+  imports: [ReactiveFormsModule, TuiIcon, TuiTextfield, TuiInputTime, LifeelButton],
   templateUrl: './sport-activities-settings-widget.component.html',
   styleUrls: ['./sport-activities-settings-widget.component.less'],
 })


### PR DESCRIPTION
This pull request introduces a new custom button component, `LifeelButton`, to the UI kit and replaces all usages of the previous Taiga UI button components across the application with this new component. It also updates documentation and global styles to support the new button and ensure consistent styling.

**Introduction of the new button component:**

* Added a new `LifeelButton` component with customizable `variant`, `size`, `loading`, and `disabled` states, including a dedicated LESS stylesheet and Storybook stories for documentation and testing. (`libs/front/ui-kit/src/lib/components/button/button.component.ts`, `libs/front/ui-kit/src/lib/components/button/button.component.html`, `libs/front/ui-kit/src/lib/components/button/button.component.less`, `libs/front/ui-kit/src/lib/components/button/button.component.stories.ts`, `libs/front/ui-kit/src/index.ts`, `libs/front/ui-kit/src/lib/tokens/tokens.ts`) [[1]](diffhunk://#diff-afce083f4932108c221a01a14cb224da900d26bf2dec1a6c53c3e0057f90918fR1-R38) [[2]](diffhunk://#diff-b5b4aa8e3ba156e5805a0d1f2588013f3fdce15216f9bb2feb239a71add96083R1-R7) [[3]](diffhunk://#diff-92c4ab122b8b40b0fb8298602dece040a283ad592218184c16f96f29aca5344cR1-R113) [[4]](diffhunk://#diff-cebd8cc5e5dfca37b460cf9887339609899beb2d10dfc1cceedbc9e76b6c8473R1-R225) [[5]](diffhunk://#diff-22c9394ba3a49c7c99b48d7a3fc47ee1eb5c017e649019c1c0ec9cdf7fe7497aR3-R5) [[6]](diffhunk://#diff-94a700e3f1974db7fd5336e7ce298a0c214437ed8de0f772e2561553fb13d878R242-R243)

**Migration to the new button:**

* Replaced all instances of Taiga UI button components (`tuiButton`, `TuiButton`, etc.) in authentication, settings, dialogs, and header components with `lifeelButton` and updated imports accordingly. (`apps/front/src/app/auth/login/login.component.html`, `apps/front/src/app/auth/login/login.component.ts`, `apps/front/src/app/auth/sign-up/sign-up.component.html`, `apps/front/src/app/auth/sign-up/sign-up.component.ts`, `apps/front/src/app/settings/widget-layout-settings/widget-layout-settings.component.html`, `apps/front/src/app/settings/widget-layout-settings/widget-layout-settings.component.ts`, `libs/front/ui/day-card-dialog/src/lib/day-card-dialog/day-card-dialog.component.html`, `libs/front/ui/day-card-dialog/src/lib/day-card-dialog/day-card-dialog.component.ts`, `libs/front/ui/header/src/lib/header/header.component.html`) [[1]](diffhunk://#diff-f630f7462f4469104048ac9df5985dbc121c668a4f63a102d79779dde4fb713cL36-R37) [[2]](diffhunk://#diff-2245524ef6d41374199da9afe4199bd9925194406c507ca62fc467af2fa5073eL13-R16) [[3]](diffhunk://#diff-2245524ef6d41374199da9afe4199bd9925194406c507ca62fc467af2fa5073eL37-R39) [[4]](diffhunk://#diff-5d8b2ea484b1636e74fe489a1e67a4d0e48de53228e67d7be28acfeeaff9154eL65-R66) [[5]](diffhunk://#diff-30c65baa9f171e0fd1388dbda37de2342a2f9d4cc893444a780448715cccc624L13-R16) [[6]](diffhunk://#diff-30c65baa9f171e0fd1388dbda37de2342a2f9d4cc893444a780448715cccc624L54-R50) [[7]](diffhunk://#diff-4339a576f3f2b894bbbf5d32a89bec7b56029b1b45151340ae09e30bb66c2e5fL38-R38) [[8]](diffhunk://#diff-e5b0df0d5804aa0efbfb349a8f980d079a0eb49e8cec6904462489b900857461L5-R15) [[9]](diffhunk://#diff-e5b0df0d5804aa0efbfb349a8f980d079a0eb49e8cec6904462489b900857461L37-R39) [[10]](diffhunk://#diff-bd341763c7ab6feaaf8b393679e87a40d04e0d543f012dcae453d82798233172L33-R34) [[11]](diffhunk://#diff-d6011936f1ba39bf3d7971e13de4f3da98d2b972957b0049670a57e0a6274b40L11-R16) [[12]](diffhunk://#diff-d6011936f1ba39bf3d7971e13de4f3da98d2b972957b0049670a57e0a6274b40L32-R40) [[13]](diffhunk://#diff-3e77d91ae3cb362436fe80013a3fcca486cdae268b7c5021cbcd3fc364140874L36-R35)

**Documentation and selector convention updates:**

* Updated the UI kit README and Storybook documentation to reflect the new `lifeelButton` selector and usage examples, replacing all references to the old `lfButton`. (`libs/front/ui-kit/README.md`) [[1]](diffhunk://#diff-2aae454ba7288d4a8201fbd72d0d790650ac7e4fbe20e13aa1bf813980f79751L64-R64) [[2]](diffhunk://#diff-2aae454ba7288d4a8201fbd72d0d790650ac7e4fbe20e13aa1bf813980f79751L126-R126) [[3]](diffhunk://#diff-2aae454ba7288d4a8201fbd72d0d790650ac7e4fbe20e13aa1bf813980f79751L162-R162) [[4]](diffhunk://#diff-2aae454ba7288d4a8201fbd72d0d790650ac7e4fbe20e13aa1bf813980f79751L180-R182) [[5]](diffhunk://#diff-2aae454ba7288d4a8201fbd72d0d790650ac7e4fbe20e13aa1bf813980f79751L193-R193)

**Global style improvements:**

* Applied a global CSS reset using `box-sizing: border-box` and removed default margin and padding for all elements to ensure consistency across the app. (`apps/front/src/styles.less`)

**Minor UI consistency fixes:**

* Standardized button sizes (e.g., using `size="lg"` instead of `size="l"`) for consistency with the new component. [[1]](diffhunk://#diff-f630f7462f4469104048ac9df5985dbc121c668a4f63a102d79779dde4fb713cL36-R37) [[2]](diffhunk://#diff-5d8b2ea484b1636e74fe489a1e67a4d0e48de53228e67d7be28acfeeaff9154eL65-R66) [[3]](diffhunk://#diff-4339a576f3f2b894bbbf5d32a89bec7b56029b1b45151340ae09e30bb66c2e5fL38-R38) [[4]](diffhunk://#diff-bd341763c7ab6feaaf8b393679e87a40d04e0d543f012dcae453d82798233172L33-R34)

These changes ensure a unified look and behavior for buttons throughout the application, simplify button customization, and improve maintainability by consolidating button logic into a single, well-documented component.