### PR TITLE
Add avatar component and replace TuiAvatar in widget

### DIFF
--- a/libs/front/ui-kit/src/index.ts
+++ b/libs/front/ui-kit/src/index.ts
@@ -13,3 +13,6 @@ export * from './lib/components/chip/chip.component';
 
 // Badge
 export * from './lib/components/badge/badge.component';
+
+// Avatar
+export * from './lib/components/avatar/avatar.component';

--- a/libs/front/ui-kit/src/lib/components/avatar/avatar.component.html
+++ b/libs/front/ui-kit/src/lib/components/avatar/avatar.component.html
@@ -1,0 +1,7 @@
+@let imageSrc = src();
+
+@if (imageSrc) {
+  <img [src]="imageSrc" alt="User avatar" class="image" />
+} @else {
+  {{ initials() }}
+}

--- a/libs/front/ui-kit/src/lib/components/avatar/avatar.component.html
+++ b/libs/front/ui-kit/src/lib/components/avatar/avatar.component.html
@@ -2,6 +2,8 @@
 
 @if (imageSrc) {
   <img [src]="imageSrc" alt="User avatar" class="image" />
-} @else {
+} @else if (initials()) {
   {{ initials() }}
+} @else {
+  <ng-content />
 }

--- a/libs/front/ui-kit/src/lib/components/avatar/avatar.component.less
+++ b/libs/front/ui-kit/src/lib/components/avatar/avatar.component.less
@@ -1,0 +1,43 @@
+@import '../../styles/tokens.less';
+
+:host {
+  display: grid;
+  place-items: center;
+
+  border-radius: var(--radius-full);
+  background: linear-gradient(
+    135deg,
+    var(--color-avatar-gradient-start),
+    var(--color-avatar-gradient-end)
+  );
+  color: var(--color-text-on-accent);
+
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+}
+
+:host(.lifeel-avatar--s) {
+  width: 1.75rem;
+  height: 1.75rem;
+  font-size: var(--font-size-xs);
+}
+
+:host(.lifeel-avatar--m) {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+:host(.lifeel-avatar--l) {
+  width: 3.5rem;
+  height: 3.5rem;
+  font-size: var(--font-size-l);
+}
+
+
+.image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: var(--radius-full);
+}

--- a/libs/front/ui-kit/src/lib/components/avatar/avatar.component.less
+++ b/libs/front/ui-kit/src/lib/components/avatar/avatar.component.less
@@ -13,8 +13,12 @@
   color: var(--color-text-on-accent);
 
   font-family: var(--font-family-sans);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-s);
   font-weight: var(--font-weight-semibold);
+}
+
+:host(.is-square) {
+  border-radius: var(--radius-m);
 }
 
 :host(.lifeel-avatar--s) {
@@ -34,10 +38,9 @@
   font-size: var(--font-size-l);
 }
 
-
 .image {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: var(--radius-full);
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
 }

--- a/libs/front/ui-kit/src/lib/components/avatar/avatar.component.stories.ts
+++ b/libs/front/ui-kit/src/lib/components/avatar/avatar.component.stories.ts
@@ -1,0 +1,36 @@
+import { Meta, StoryObj } from '@storybook/angular';
+import { LifeelAvatar } from './avatar.component';
+
+const meta: Meta<LifeelAvatar> = {
+  title: 'UI Kit/Avatar',
+  component: LifeelAvatar,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['xs', 's', 'm', 'l', 'xl'],
+    },
+    src: {
+      control: 'text',
+    },
+    initials: {
+      control: 'text',
+    },
+    isSquare: {
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<LifeelAvatar>;
+
+export const Default: Story = {
+  args: {
+    size: 'm',
+    src: 'https://randomuser.me/api/portraits/men/75.jpg',
+    initials: 'JD',
+    isSquare: false,
+  },
+};

--- a/libs/front/ui-kit/src/lib/components/avatar/avatar.component.ts
+++ b/libs/front/ui-kit/src/lib/components/avatar/avatar.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Size } from '../../tokens/tokens';
+
+@Component({
+  selector: 'lifeel-avatar',
+  templateUrl: './avatar.component.html',
+  styleUrls: ['./avatar.component.less'],
+  standalone: true,
+  host: {
+    '[class]': 'hostClasses()',
+  },
+
+  imports: [],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LifeelAvatar {
+  public readonly size = input.required<Size>();
+
+  public readonly src = input<string | null>(null);
+
+  public readonly initials = input<string>('');
+
+  public readonly isSquare = input<boolean>(false);
+
+  protected readonly hostClasses = computed(() => {
+    return ['lifeel-avatar', `lifeel-avatar--${this.size()}`, this.isSquare() ? 'is-square' : '']
+      .filter(Boolean)
+      .join(' ');
+  });
+}

--- a/libs/front/ui-kit/src/lib/styles/tokens.less
+++ b/libs/front/ui-kit/src/lib/styles/tokens.less
@@ -89,7 +89,7 @@
   --color-accent-secondary: var(--_color-mint-500);
 
   /* Category (stable semantic mapping, independent of mode) */
-  --color-category-health: var( --_color-emerald-500);
+  --color-category-health: var(--_color-emerald-500);
   --color-category-leisure: var(--_color-coral-500);
   --color-category-routine: var(--_color-violet-500);
   --color-category-selfdev: var(--_color-amber-500);
@@ -99,6 +99,10 @@
   --color-feedback-warning: var(--_color-warning-500);
   --color-feedback-danger: var(--_color-danger-500);
   --color-feedback-info: var(--_color-info-500);
+
+  /* Specific components */
+  --color-avatar-gradient-start: var(--_color-lavender-300);
+  --color-avatar-gradient-end: var(--_color-lavender-500);
 
   /* ────────────────────────────── TYPOGRAPHY ─────────────────────────────── */
   --font-family-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;

--- a/libs/front/ui/sport-activities-widget/src/lib/sport-activities-widget.component.html
+++ b/libs/front/ui/sport-activities-widget/src/lib/sport-activities-widget.component.html
@@ -3,9 +3,9 @@
 @for (activity of $activities(); track $index) {
   @if (activity) {
     <div [class]="`activity ${size}`">
-      <tui-avatar class="icon" [size]="size" [tuiHint]="activity.comment">
+      <lifeel-avatar class="icon" [size]="size" [tuiHint]="activity.comment">
         {{ activity.emoji }}
-      </tui-avatar>
+      </lifeel-avatar>
       <span>{{ activity.duration | time }}</span>
     </div>
   }

--- a/libs/front/ui/sport-activities-widget/src/lib/sport-activities-widget.component.ts
+++ b/libs/front/ui/sport-activities-widget/src/lib/sport-activities-widget.component.ts
@@ -1,13 +1,13 @@
 import { Component, computed, inject, Signal } from '@angular/core';
 import { TuiHint } from '@taiga-ui/core';
-import { TuiAvatar } from '@taiga-ui/kit';
 import { TimePipe } from '@lifestyle-dashboard/time-pipe';
+import { LifeelAvatar, Size } from '@lifestyle-dashboard/ui-kit';
 import { SportActivitiesWidgetInput } from './sport-activities-widget-input';
 import { SPORT_ACTIVITIES_WIDGET_TOKEN } from './sport-activities-widget.token';
 
 @Component({
   selector: 'lifestyle-dashboard-sport-activities-widget',
-  imports: [TimePipe, TuiAvatar, TuiHint],
+  imports: [TimePipe, TuiHint, LifeelAvatar],
   templateUrl: './sport-activities-widget.component.html',
   styleUrls: ['./sport-activities-widget.component.less'],
 })
@@ -16,7 +16,7 @@ export class SportActivitiesWidgetComponent {
     SPORT_ACTIVITIES_WIDGET_TOKEN,
   );
 
-  public readonly $size = computed(() => this.widgetData()?.size as TuiAvatar['size']);
+  public readonly $size = computed(() => this.widgetData()?.size as Size);
 
   public readonly $activities = computed(() => this.widgetData()?.data ?? []);
 }


### PR DESCRIPTION
This pull request introduces a new `Avatar` component to the UI kit and updates the sport activities widget to use this new component instead of the previous third-party avatar. The changes include the creation of the component, its styling, Storybook integration, and the necessary updates to the widget to support and display the new avatar.

**New Avatar Component:**

- Added a new `LifeelAvatar` component with support for displaying either an image or user initials, customizable size, and optional square/rounded appearance. (`avatar.component.ts`, `avatar.component.html`) [[1]](diffhunk://#diff-524e4af86c7d68fad2df8f4e3fb940a9256240a64a7f80865de05ecd3de2db84R1-R30) [[2]](diffhunk://#diff-b70dd079bb798df17065eaffa7b5de4ca64e6dfb721bbbee897b3206674f3f2dR1-R7)
- Implemented dedicated styles for the avatar, including gradient backgrounds and responsive sizing based on tokens. (`avatar.component.less`, `tokens.less`) [[1]](diffhunk://#diff-bc03d7b739f1a3657d5427eca290ff93aa4a949bc2e8178e4e7f79deb6423edaR1-R43) [[2]](diffhunk://#diff-097b13fe16052c13c0cbb8ac1ccc730419c2b462eb6bcbc8d0c83186280b1540R103-R106)
- Registered the new component in the UI kit's public API for external use. (`index.ts`)
- Added Storybook stories for the new avatar to facilitate testing and documentation. (`avatar.component.stories.ts`)

**Integration with Sport Activities Widget:**

- Replaced the use of the third-party `TuiAvatar` with the new `LifeelAvatar` in the sport activities widget, including updates to imports, template usage, and type references. (`sport-activities-widget.component.ts`, `sport-activities-widget.component.html`) [[1]](diffhunk://#diff-4a0e34265b6f8d6586f44ab756ff207f8e8092f730255e0c28cc79b324a6cff0L3-R10) [[2]](diffhunk://#diff-4a0e34265b6f8d6586f44ab756ff207f8e8092f730255e0c28cc79b324a6cff0L19-R19) [[3]](diffhunk://#diff-579b1df4cffa6e386d9d1cf5f226e1579d451bdc34e46c07280db1f0b2e7a4a4L6-R8)